### PR TITLE
disable vertical scrollbars

### DIFF
--- a/styles/slides.css
+++ b/styles/slides.css
@@ -1,5 +1,6 @@
 html,
 body {
+	margin: 0;
 	height: 100%;
 	font-family: 'Fira Sans', sans-serif;
 	font-size: 16px;


### PR DESCRIPTION
Every slide has vertical scrollbars. This can be fixed mit normalize.css, or simply with a margin:0 on body/html